### PR TITLE
ImageField and naive callable upload_to support.

### DIFF
--- a/django_any/models.py
+++ b/django_any/models.py
@@ -210,6 +210,7 @@ def any_float_field(field, **kwargs):
 
 
 @any_field.register(models.FileField)
+@any_field.register(models.ImageField)
 def any_file_field(field, **kwargs):
     """
     Lookup for nearest existing file
@@ -228,7 +229,12 @@ def any_file_field(field, **kwargs):
             if result:
                 return result
             
-    result = get_some_file(field.upload_to)
+    if callable(field.upload_to):
+        generated_filepath = field.upload_to(None, xunit.any_string(ascii_letters, 10, 20))
+        upload_to = os.path.dirname(generated_filepath)
+    else:
+        upload_to = field.upload_to
+    result = get_some_file(upload_to)
 
     if result is None and not field.null:
         raise TypeError("Can't found file in %s for non nullable FileField" % field.upload_to)

--- a/django_any/test.py
+++ b/django_any/test.py
@@ -96,7 +96,7 @@ def with_seed(seed):
 
 def set_seed(func, seed=None):
     """
-    Set randon seed before executing function. If seed is 
+    Set randon seed before executing function. If seed is
     not provided current timestamp used
     """
     def _wrapper(self, seed=seed, *args, **kwargs):
@@ -113,7 +113,7 @@ class WithTestDataSeed(type):
     def __new__(cls, cls_name, bases, attrs):
         attrs['__django_any_seed'] = 0
 
-        def shortDescription(self):            
+        def shortDescription(self):
             return "%s (%s) With seed %s" % (self._testMethodName,  _strclass(self.__class__), getattr(self, '__django_any_seed'))
 
         for name, func in attrs.items():
@@ -125,7 +125,7 @@ class WithTestDataSeed(type):
 
                 for seed in getattr(func, '__django_any_with_seed', []):
                     attrs['%s_%d' % (name, seed)] = set_seed(func, seed)
-                
+
         testcase = super(WithTestDataSeed, cls).__new__(cls, cls_name, bases, attrs)
         testcase.shortDescription = shortDescription
         return testcase

--- a/django_any/tests/model_creation_simple.py
+++ b/django_any/tests/model_creation_simple.py
@@ -21,10 +21,12 @@ class SimpleModel(models.Model):
     null_boolead_field = models.NullBooleanField()
     positive_integer_field = models.PositiveIntegerField()
     small_integer = models.PositiveSmallIntegerField()
-    slig_field = models.SlugField()
+    slug_field = models.SlugField()
     text_field = models.TextField()
     time_field = models.TimeField()
     url_field = models.URLField(verify_exists=False)
+    file_field = models.FileField(upload_to='sample_subdir')
+    image_field = models.ImageField(upload_to='sample_subdir')
 
     class Meta:
         app_label = 'django_any'
@@ -33,12 +35,14 @@ class SimpleModel(models.Model):
 class SimpleCreation(TestCase):
     def test_model_creation_succeed(self):
         result = any_model(SimpleModel)
-        
-        self.assertEqual(type(result), SimpleModel)
 
-        for field in result._meta.fields:
+        self.assertEqual(type(result), SimpleModel)
+        self.assertEqual(len(result._meta.fields), len(SimpleModel._meta.local_fields))
+
+        for field, original_field in zip(result._meta.fields, SimpleModel._meta.local_fields):
             value = getattr(result, field.name)
-        self.assertTrue(value is not None, "%s is uninitialized" % field.name)
+            self.assertTrue(value is not None, "%s is uninitialized" % field.name)
+            self.assertTrue(isinstance(field, original_field.__class__), "%s has correct field type" % field.name)
 
     def _test_partial_specification(self):
         result = any_model(SimpleModel, char_field='test')

--- a/django_any/tests/model_filefield.py
+++ b/django_any/tests/model_filefield.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: django -*-
+"""
+Test model creation with FileField
+"""
+import os
+from django.db import models
+from django.test import TestCase
+from django_any import any_model
+
+class ModelWithFileFieldUploadToString(models.Model):
+    file_field = models.FileField(upload_to='sample_subdir')
+
+    class Meta:
+        app_label = 'django_any'
+
+
+def callable_upload_to(instance, filename):
+    return os.path.join('sample_subdir', filename)
+
+
+class ModelWithFileFieldUploadToCallable(models.Model):
+    file_field = models.FileField(upload_to=callable_upload_to)
+
+    class Meta:
+        app_label = 'django_any'
+
+
+class FileFiledUploadTo(TestCase):
+
+    def test_created_model_with_filefield_string_upload_to(self):
+        model = any_model(ModelWithFileFieldUploadToString)
+        self.assertEqual(model.file_field, 'sample_file.txt')
+
+    def test_created_model_with_filefield_callable_upload_to(self):
+        model = any_model(ModelWithFileFieldUploadToCallable)
+        self.assertEqual(model.file_field, 'sample_file.txt')
+


### PR DESCRIPTION
Now it's possible to generate valid values form ImageField fields (had to do it by manually registering before).
Also added very naive support for callables in `upload_to` argument.

Btw, no idea why github show this crazy diff, I actually added row after row 213 and 5 rows after 230
