### PR TITLE
Self-referencing models no longer produce "RuntimeError: maximum recursion depth exceeded

### DIFF
--- a/django_any/models.py
+++ b/django_any/models.py
@@ -443,6 +443,10 @@ def _fill_model_fields(model, **kwargs):
             """
             skip primary key field
             """
+        elif isinstance(field, models.fields.related.ForeignKey) and field.model == field.rel.to:
+            """
+            skip self relations
+            """
         else:
             setattr(model, field.name, any_field(field, **fields_args[field.name]))
 

--- a/django_any/tests/model_foreign_key.py
+++ b/django_any/tests/model_foreign_key.py
@@ -21,6 +21,14 @@ class BaseModel(models.Model):
         app_label = 'django_any'
 
 
+class SelfReferencingModel(models.Model):
+    name = models.CharField(max_length=5)
+    parent = models.ForeignKey('self', null=True, blank=True)
+
+    class Meta:
+        app_label = 'django_any'
+
+
 class ForeignKeyCreation(TestCase):
     def test_fk_relation_autocreate(self):
         result = any_model(BaseModel)
@@ -34,3 +42,10 @@ class ForeignKeyCreation(TestCase):
         result = any_model(BaseModel, related__name='test')
         self.assertEqual(result.related.name, 'test')
 
+    def test_fk_referencing_self(self):
+        self_referencing = any_model(SelfReferencingModel)
+        self.assertTrue(self_referencing.parent is None)
+
+        root = any_model(SelfReferencingModel)
+        child = any_model(SelfReferencingModel, parent=root)
+        self.assertEqual(type(child.parent), SelfReferencingModel)


### PR DESCRIPTION
Self-referencing models no longer produce "RuntimeError: maximum recursion depth exceeded"
Instead, models with foreignkey to self (like mptt trees) are always null by default.
Related to #6, but doesn't fix it.
