### PR TITLE
Models with GenericForeignKey can be created with any_model(MyModel, cont

### DIFF
--- a/django_any/models.py
+++ b/django_any/models.py
@@ -3,6 +3,7 @@
 """
 Values generators for common Django Fields
 """
+from django.contrib.contenttypes.models import ContentType
 import re, os, random
 from decimal import Decimal
 from datetime import date, datetime, time
@@ -422,6 +423,12 @@ def any_onetoone_field(field, **kwargs):
 def _fill_model_fields(model, **kwargs):
     model_fields, fields_args = split_model_kwargs(kwargs)
 
+    # fill virtual fields
+    for field in model._meta.virtual_fields:
+        if field.name in model_fields:
+            object = kwargs[field.name]
+            model_fields[field.ct_field] = kwargs[field.ct_field]= ContentType.objects.get_for_model(object)
+            model_fields[field.fk_field] = kwargs[field.fk_field]= object.id
     # fill local fields
     for field in model._meta.fields:
         if field.name in model_fields:

--- a/django_any/tests/model_field_content_object.py
+++ b/django_any/tests/model_field_content_object.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: django -*-
+"""
+Test model creation with GenericForeignKey
+"""
+from django.contrib.contenttypes import generic
+from django.contrib.contenttypes.models import ContentType
+from django.db import models
+from django.test import TestCase
+from django_any import any_model
+
+
+class BaseModel(models.Model):
+    name = models.SlugField()
+
+    class Meta:
+        app_label = 'django_any'
+
+class ModelWithGenericRelation(models.Model):
+    tag = models.SlugField()
+    content_type = models.ForeignKey(ContentType)
+    object_id = models.PositiveIntegerField()
+    content_object = generic.GenericForeignKey('content_type', 'object_id')
+
+    class Meta:
+        app_label = 'django_any'
+
+
+class ContentTypeTest(TestCase):
+    def test_verbose_generic_fk_creation(self):
+        content_object = any_model(BaseModel)
+        result = any_model(ModelWithGenericRelation,
+                           content_type=ContentType.objects.get_for_model(BaseModel),
+                           object_id=content_object.id)
+        self.assertEqual(result.content_object, content_object)
+        self.assertEqual(result.content_type, ContentType.objects.get_for_model(BaseModel))
+        self.assertEqual(result.object_id, content_object.id)
+
+    def test_short_generic_fk_creation(self):
+        content_object = any_model(BaseModel)
+        related_object = any_model(ModelWithGenericRelation,
+                                   content_object=content_object)
+        self.assertEqual(related_object.content_object, content_object)
+        self.assertEqual(related_object.content_type, ContentType.objects.get_for_model(BaseModel))
+        self.assertEqual(related_object.object_id, content_object.id)
+


### PR DESCRIPTION
Models with GenericForeignKey can be created with any_model(MyModel, content_object=object)
Fixes #8
