### PR TITLE
Generate timezone-aware dates and datetimes if the timezone support is enabled.

### DIFF
--- a/django_any/models.py
+++ b/django_any/models.py
@@ -28,9 +28,10 @@ except ImportError:
 
 if timezone:
    try:
-      from pytz import NonExistentTimeError
+      from pytz import NonExistentTimeError, AmbiguousTimeError
    except:
       class NonExistentTimeError(Exception): pass
+      class AmbiguousTimeError(Exception): pass
 
 any_field = ExtensionMethod()
 any_model = ExtensionMethod(by_instance=True)
@@ -159,7 +160,7 @@ def any_date_field(field, **kwargs):
         if getattr(settings, 'USE_TZ') and timezone:
             try:
                 t = timezone.make_aware(t, timezone.get_current_timezone())
-            except NonExistentTimeError:
+            except (NonExistentTimeError, AmbiguousTimeError):
                 continue
         break
     return t
@@ -182,7 +183,7 @@ def any_datetime_field(field, **kwargs):
         if getattr(settings, 'USE_TZ') and timezone:
             try:
                 t = timezone.make_aware(t, timezone.get_current_timezone())
-            except NonExistentTimeError:
+            except (NonExistentTimeError, AmbiguousTimeError):
                 continue
         break
     return t

--- a/django_any/models.py
+++ b/django_any/models.py
@@ -404,8 +404,7 @@ def any_url_field(field, **kwargs):
 
     if not url:
         verified = [validator for validator in field.validators \
-                    if isinstance(validator, validators.URLValidator) and \
-                    validator.verify_exists == True]
+                    if isinstance(validator, validators.URLValidator)]
         if verified:
             url = choice(['http://news.yandex.ru/society.html',
                           'http://video.google.com/?hl=en&tab=wv',


### PR DESCRIPTION
One can get a huge amount of warnings looking like this:

/django/db/models/fields/**init**.py:808: RuntimeWarning: DateTimeField received a naive datetime (1999-01-25 20:06:41) while time zone support is active.

when the Django 1.4 timezone support is enabled.

This patch fixes the issue.

It also fixes another issue: sometimes a generated datetime value becomes invalid when timezone rules are applied to it. Each year we skip a hour when applying daytime saving time rules. Sometimes a generated 'naive' value hits one of these skipped hours when become a timezone-aware. This may result in random errors and test failures.
